### PR TITLE
[rust] Disable statx for all builds. JB#50106

### DIFF
--- a/disable-statx.patch
+++ b/disable-statx.patch
@@ -1,0 +1,34 @@
+Disable statx for all builds.
+
+libstd implements statx using syscall and thus it will not work on
+scratchbox2. Moreover as it is supported only by Linux 4.11 and newer
+it's little use for us at the moment. It can be disabled and which means
+that optional extra information is set to None. Software should handle
+that gracefully without issues thanks to rust's type system.
+
+---
+--- rustc-1.44.0-src/src/libstd/sys/unix/fs.rs.old	2020-06-01 18:44:16.000000000 +0300
++++ rustc-1.44.0-src/src/libstd/sys/unix/fs.rs	2020-06-26 12:42:46.438070586 +0300
+@@ -58,20 +58,9 @@
+ // https://github.com/rust-lang/rust/pull/67774
+ macro_rules! cfg_has_statx {
+     ({ $($then_tt:tt)* } else { $($else_tt:tt)* }) => {
+-        cfg_if::cfg_if! {
+-            if #[cfg(all(target_os = "linux", target_env = "gnu"))] {
+-                $($then_tt)*
+-            } else {
+-                $($else_tt)*
+-            }
+-        }
+-    };
+-    ($($block_inner:tt)*) => {
+-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+-        {
+-            $($block_inner)*
+-        }
++        $($else_tt)*
+     };
++    ($($block_inner:tt)*) => {};
+ }
+ 
+ cfg_has_statx! {{

--- a/rust.changes
+++ b/rust.changes
@@ -1,2 +1,5 @@
-* Thu Jun 12 2020 Raine Makelainen <raine.makelainen@jolla.com> - 1.44.0+git1
+* Fri Jun 26 2020 Tomi Leppänen <tomi.leppanen@jolla.com> - 1.44.0+git2
+- [rust] Disable statx for all builds. JB#50106
+
+* Fri Jun 12 2020 Raine Makelainen <raine.makelainen@jolla.com> - 1.44.0+git1
 - [rust] Packaging for 1.44.0 version. JB#50106

--- a/rust.spec
+++ b/rust.spec
@@ -16,7 +16,7 @@
 
 Name:           rust
 # TODO: Suffix version at the end with +git1
-Version:        %{rust_version}+git1
+Version:        %{rust_version}+git2
 Release:        1
 Summary:        The Rust Programming Language
 License:        (ASL 2.0 or MIT) and (BSD and MIT)
@@ -29,6 +29,7 @@ Source1:        https://static.rust-lang.org/dist/rust-%{rust_version}-%{rust_tr
 
 Patch1: 0001-Use-a-non-existent-test-path-instead-of-clobbering-d.patch
 Patch2: llvm-targets.patch
+Patch3: disable-statx.patch
 
 %global bootstrap_root rust-%{rust_version}-%{rust_triple}
 %global local_rust_root %{_builddir}/%{bootstrap_root}/usr
@@ -155,6 +156,7 @@ test -f '%{local_rust_root}/bin/rustc'
 
 %patch1 -p1
 %patch2 -p0
+%patch3 -p1
 
 sed -i.try-py3 -e '/try python2.7/i try python3 "$@"' ./configure
 


### PR DESCRIPTION
libstd implements statx using syscall and thus it will not work on
scratchbox2. Moreover as it is supported only by Linux 4.11 and newer
it's little use for us at the moment. It can be disabled and which means
that optional extra information is set to None. Software should handle
that gracefully without issues thanks to rust's type system.