### PR TITLE
Let Cargo obey the SB2_TARGET variable

### DIFF
--- a/0007-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
+++ b/0007-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
@@ -1,0 +1,35 @@
+From f5d252ef690390c2cb9948995ccf68aeae2b123e Mon Sep 17 00:00:00 2001
+From: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date: Thu, 27 Jan 2022 16:32:39 +0100
+Subject: [PATCH] Scratchbox2 needs to be able to tell cargo the default
+ target.
+
+This is analogous to the SB2 patch to rustc; ac226bbc018e11311394126fe580763c5bc77a2c
+
+Signed-off-by: Ruben De Smet <ruben.de.smet@rubdos.be>
+---
+ src/cargo/core/compiler/compile_kind.rs | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/tools/cargo/src/cargo/core/compiler/compile_kind.rs b/src/tools/cargo/src/cargo/core/compiler/compile_kind.rs
+index adfa55f..8d892a0 100644
+--- a/src/tools/cargo/src/cargo/core/compiler/compile_kind.rs
++++ b/src/tools/cargo/src/cargo/core/compiler/compile_kind.rs
+@@ -76,7 +76,13 @@ impl CompileKind {
+                 };
+                 CompileKind::Target(CompileTarget::new(&value)?)
+             }
+-            None => CompileKind::Host,
++            None => {
++                if let Ok(sb2_tgt) = std::env::var("SB2_RUST_TARGET_TRIPLE") {
++                    CompileKind::Target(CompileTarget::new(&sb2_tgt)?)
++                } else {
++                    CompileKind::Host
++                }
++            }
+         };
+         Ok(vec![kind])
+     }
+-- 
+2.31.1
+

--- a/rust.spec
+++ b/rust.spec
@@ -62,6 +62,7 @@ Patch3: 0003-Disable-statx-for-all-builds.-JB-50106.patch
 Patch4: 0004-Scratchbox2-needs-to-be-able-to-tell-rustc-the-defau.patch
 Patch5: 0005-Cargo-Force-the-target-when-building-for-CompileKind-Host.patch
 Patch6: 0006-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
+Patch7: 0007-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
 # This is the real rustc spec - the stub one appears near the end.
 %ifarch %ix86
 


### PR DESCRIPTION
`cargo` should also know about the `SB2_RUST_TARGET_TRIPLE` variable, because `cargo` can conditionally add or remove dependencies based on target information. For example, `polyval` and other cryptographic crates like `sha-1` and `sha2` have statements like this:

```toml
[target."cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))".dependencies.cpufeatures]
version = "0.2"
```

This can lead to very strange errors, because a dependency that is stated in Cargo.toml does not get injected in the build process.

```
error[E0433]: failed to resolve: use of undeclared crate or module `cpufeatures`
  --> /home/rsmet/.cargo/registry/src/github.com-1285ae84e5963aae/polyval-0.5.3/src/backend/autodetect.rs:18:1
   |
18 | cpufeatures::new!(mul_intrinsics, "pclmulqdq", "sse4.1");
   | ^^^^^^^^^^^ use of undeclared crate or module `cpufeatures`
```

This is a blocker for Whisperfish to be build with the SailfishOS SDK, especially now that Rust 1.52 is available!

I don't know to what extend this should be a real `format-patch`/e-mail style patch for Jolla to accept this here, let me know if I should clean that up a little.

PS., I had a [1.51 branch](https://github.com/rubdos/sailfish-rust/tree/try-1.51) laying around, seems like you folks had to duplicate my efforts. Sorry for not notifying you!