### PR TITLE
Rust 1.64: Revert statx patch for sb2 compatibility

### DIFF
--- a/0008-Revert-Use-statxs-64-bit-times-on-32-bit-linux-gnu.patch
+++ b/0008-Revert-Use-statxs-64-bit-times-on-32-bit-linux-gnu.patch
@@ -1,0 +1,250 @@
+commit 15909315c49d896281fa6564974924454d094ac8
+Author: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date:   Mon Oct 23 20:39:13 2023 +0200
+
+    Revert "Use statx's 64-bit times on 32-bit linux-gnu"
+    
+    Additionally adds a `dead_code` lint supression on SystemTime::new.
+    
+    This reverts commit fec4818fdb40c82679f57fa7f26fcddc1a874c13.
+
+diff --git a/library/std/src/os/linux/fs.rs b/library/std/src/os/linux/fs.rs
+index 479bbcc17a8..2e90d8d6be7 100644
+--- a/library/std/src/os/linux/fs.rs
++++ b/library/std/src/os/linux/fs.rs
+@@ -356,34 +356,19 @@ fn st_size(&self) -> u64 {
+         self.as_inner().as_inner().st_size as u64
+     }
+     fn st_atime(&self) -> i64 {
+-        let file_attr = self.as_inner();
+-        #[cfg(all(target_env = "gnu", target_pointer_width = "32"))]
+-        if let Some(atime) = file_attr.stx_atime() {
+-            return atime.tv_sec;
+-        }
+-        file_attr.as_inner().st_atime as i64
++        self.as_inner().as_inner().st_atime as i64
+     }
+     fn st_atime_nsec(&self) -> i64 {
+         self.as_inner().as_inner().st_atime_nsec as i64
+     }
+     fn st_mtime(&self) -> i64 {
+-        let file_attr = self.as_inner();
+-        #[cfg(all(target_env = "gnu", target_pointer_width = "32"))]
+-        if let Some(mtime) = file_attr.stx_mtime() {
+-            return mtime.tv_sec;
+-        }
+-        file_attr.as_inner().st_mtime as i64
++        self.as_inner().as_inner().st_mtime as i64
+     }
+     fn st_mtime_nsec(&self) -> i64 {
+         self.as_inner().as_inner().st_mtime_nsec as i64
+     }
+     fn st_ctime(&self) -> i64 {
+-        let file_attr = self.as_inner();
+-        #[cfg(all(target_env = "gnu", target_pointer_width = "32"))]
+-        if let Some(ctime) = file_attr.stx_ctime() {
+-            return ctime.tv_sec;
+-        }
+-        file_attr.as_inner().st_ctime as i64
++        self.as_inner().as_inner().st_ctime as i64
+     }
+     fn st_ctime_nsec(&self) -> i64 {
+         self.as_inner().as_inner().st_ctime_nsec as i64
+diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
+index b5cc8038ca4..e65dcfcd78b 100644
+--- a/library/std/src/sys/unix/fs.rs
++++ b/library/std/src/sys/unix/fs.rs
+@@ -115,19 +115,10 @@ struct StatxExtraFields {
+         // This is needed to check if btime is supported by the filesystem.
+         stx_mask: u32,
+         stx_btime: libc::statx_timestamp,
+-        // With statx, we can overcome 32-bit `time_t` too.
+-        #[cfg(target_pointer_width = "32")]
+-        stx_atime: libc::statx_timestamp,
+-        #[cfg(target_pointer_width = "32")]
+-        stx_ctime: libc::statx_timestamp,
+-        #[cfg(target_pointer_width = "32")]
+-        stx_mtime: libc::statx_timestamp,
+-
+     }
+ 
+-    // We prefer `statx` on Linux if available, which contains file creation time,
+-    // as well as 64-bit timestamps of all kinds.
+-    // Default `stat64` contains no creation time and may have 32-bit `time_t`.
++    // We prefer `statx` on Linux if available, which contains file creation time.
++    // Default `stat64` contains no creation time.
+     unsafe fn try_statx(
+         fd: c_int,
+         path: *const c_char,
+@@ -203,13 +194,6 @@ fn statx(
+         let extra = StatxExtraFields {
+             stx_mask: buf.stx_mask,
+             stx_btime: buf.stx_btime,
+-            // Store full times to avoid 32-bit `time_t` truncation.
+-            #[cfg(target_pointer_width = "32")]
+-            stx_atime: buf.stx_atime,
+-            #[cfg(target_pointer_width = "32")]
+-            stx_ctime: buf.stx_ctime,
+-            #[cfg(target_pointer_width = "32")]
+-            stx_mtime: buf.stx_mtime,
+         };
+ 
+         Some(Ok(FileAttr { stat, statx_extra_fields: Some(extra) }))
+@@ -331,36 +315,6 @@ impl FileAttr {
+         fn from_stat64(stat: stat64) -> Self {
+             Self { stat, statx_extra_fields: None }
+         }
+-
+-        #[cfg(target_pointer_width = "32")]
+-        pub fn stx_mtime(&self) -> Option<&libc::statx_timestamp> {
+-            if let Some(ext) = &self.statx_extra_fields {
+-                if (ext.stx_mask & libc::STATX_MTIME) != 0 {
+-                    return Some(&ext.stx_mtime);
+-                }
+-            }
+-            None
+-        }
+-
+-        #[cfg(target_pointer_width = "32")]
+-        pub fn stx_atime(&self) -> Option<&libc::statx_timestamp> {
+-            if let Some(ext) = &self.statx_extra_fields {
+-                if (ext.stx_mask & libc::STATX_ATIME) != 0 {
+-                    return Some(&ext.stx_atime);
+-                }
+-            }
+-            None
+-        }
+-
+-        #[cfg(target_pointer_width = "32")]
+-        pub fn stx_ctime(&self) -> Option<&libc::statx_timestamp> {
+-            if let Some(ext) = &self.statx_extra_fields {
+-                if (ext.stx_mask & libc::STATX_CTIME) != 0 {
+-                    return Some(&ext.stx_ctime);
+-                }
+-            }
+-            None
+-        }
+     }
+ } else {
+     impl FileAttr {
+@@ -386,15 +340,24 @@ pub fn file_type(&self) -> FileType {
+ #[cfg(target_os = "netbsd")]
+ impl FileAttr {
+     pub fn modified(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_mtime as i64, self.stat.st_mtimensec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_mtime as libc::time_t,
++            tv_nsec: self.stat.st_mtimensec as libc::c_long,
++        }))
+     }
+ 
+     pub fn accessed(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_atime as i64, self.stat.st_atimensec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_atime as libc::time_t,
++            tv_nsec: self.stat.st_atimensec as libc::c_long,
++        }))
+     }
+ 
+     pub fn created(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_birthtime as i64, self.stat.st_birthtimensec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_birthtime as libc::time_t,
++            tv_nsec: self.stat.st_birthtimensec as libc::c_long,
++        }))
+     }
+ }
+ 
+@@ -402,19 +365,18 @@ pub fn created(&self) -> io::Result<SystemTime> {
+ impl FileAttr {
+     #[cfg(not(any(target_os = "vxworks", target_os = "espidf", target_os = "horizon")))]
+     pub fn modified(&self) -> io::Result<SystemTime> {
+-        #[cfg(target_pointer_width = "32")]
+-        cfg_has_statx! {
+-            if let Some(mtime) = self.stx_mtime() {
+-                return Ok(SystemTime::new(mtime.tv_sec, mtime.tv_nsec as i64));
+-            }
+-        }
+-
+-        Ok(SystemTime::new(self.stat.st_mtime as i64, self.stat.st_mtime_nsec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_mtime as libc::time_t,
++            tv_nsec: self.stat.st_mtime_nsec as _,
++        }))
+     }
+ 
+     #[cfg(any(target_os = "vxworks", target_os = "espidf"))]
+     pub fn modified(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_mtime as i64, 0))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_mtime as libc::time_t,
++            tv_nsec: 0,
++        }))
+     }
+ 
+     #[cfg(target_os = "horizon")]
+@@ -424,19 +386,18 @@ pub fn modified(&self) -> io::Result<SystemTime> {
+ 
+     #[cfg(not(any(target_os = "vxworks", target_os = "espidf", target_os = "horizon")))]
+     pub fn accessed(&self) -> io::Result<SystemTime> {
+-        #[cfg(target_pointer_width = "32")]
+-        cfg_has_statx! {
+-            if let Some(atime) = self.stx_atime() {
+-                return Ok(SystemTime::new(atime.tv_sec, atime.tv_nsec as i64));
+-            }
+-        }
+-
+-        Ok(SystemTime::new(self.stat.st_atime as i64, self.stat.st_atime_nsec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_atime as libc::time_t,
++            tv_nsec: self.stat.st_atime_nsec as _,
++        }))
+     }
+ 
+     #[cfg(any(target_os = "vxworks", target_os = "espidf"))]
+     pub fn accessed(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_atime as i64, 0))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_atime as libc::time_t,
++            tv_nsec: 0,
++        }))
+     }
+ 
+     #[cfg(target_os = "horizon")]
+@@ -452,7 +413,10 @@ pub fn accessed(&self) -> io::Result<SystemTime> {
+         target_os = "watchos",
+     ))]
+     pub fn created(&self) -> io::Result<SystemTime> {
+-        Ok(SystemTime::new(self.stat.st_birthtime as i64, self.stat.st_birthtime_nsec as i64))
++        Ok(SystemTime::from(libc::timespec {
++            tv_sec: self.stat.st_birthtime as libc::time_t,
++            tv_nsec: self.stat.st_birthtime_nsec as libc::c_long,
++        }))
+     }
+ 
+     #[cfg(not(any(
+@@ -466,7 +430,10 @@ pub fn created(&self) -> io::Result<SystemTime> {
+         cfg_has_statx! {
+             if let Some(ext) = &self.statx_extra_fields {
+                 return if (ext.stx_mask & libc::STATX_BTIME) != 0 {
+-                    Ok(SystemTime::new(ext.stx_btime.tv_sec, ext.stx_btime.tv_nsec as i64))
++                    Ok(SystemTime::from(libc::timespec {
++                        tv_sec: ext.stx_btime.tv_sec as libc::time_t,
++                        tv_nsec: ext.stx_btime.tv_nsec as _,
++                    }))
+                 } else {
+                     Err(io::const_io_error!(
+                         io::ErrorKind::Uncategorized,
+diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
+index dff973f59d1..067b08f05cc 100644
+--- a/library/std/src/sys/unix/time.rs
++++ b/library/std/src/sys/unix/time.rs
+@@ -19,6 +19,7 @@ pub(in crate::sys::unix) struct Timespec {
+ 
+ impl SystemTime {
+     #[cfg_attr(target_os = "horizon", allow(unused))]
++    #[cfg_attr(target_env = "gnu", allow(dead_code))]
+     pub fn new(tv_sec: i64, tv_nsec: i64) -> SystemTime {
+         SystemTime { t: Timespec::new(tv_sec, tv_nsec) }
+     }
+

--- a/rust.spec
+++ b/rust.spec
@@ -76,6 +76,7 @@ Patch4: 0004-Force-the-target-when-building-for-CompileKind-Host.patch
 Patch5: 0005-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
 Patch6: 0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
 Patch7: 0007-Disable-aarch64-outline-atomics-for-now.patch
+Patch8: 0008-Revert-Use-statxs-64-bit-times-on-32-bit-linux-gnu.patch
 # This is the real rustc spec - the stub one appears near the end.
 %ifarch %ix86
 

--- a/rust.spec
+++ b/rust.spec
@@ -445,6 +445,7 @@ rm -f %{buildroot}%{rustlibdir}/%{rust_aarch64_triple}/bin/rust-ll*
 
 # Remove cargo-credential-1password
 rm -f %{buildroot}%{_libexecdir}/cargo-credential-1password
+rm -f %{buildroot}%{_libexecdir}/rust-analyzer-proc-macro-srv
 
 %check
 # Disabled for efficient rebuilds until the hanging fix is completed


### PR DESCRIPTION
I noticed you were trying out 1.64. Instead of implementing statx in sb2, reverting the statx compatibility patches was actually rather easy, and might provide a workaround.

I tried building this against LLVM 16, but apparently the highest supported LLVM is 14 for 1.64, so I'll retry against that and report back.

Part of [The Rust Plan](https://github.com/sailfishos/llvm/pull/3)