### PR TITLE
WIP: [rust] update to 1.82.0.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/0002-Disable-statx-for-all-builds.-JB-50106.patch
+++ b/0002-Disable-statx-for-all-builds.-JB-50106.patch
@@ -21,38 +21,27 @@ Signed-off-by: Ruben De Smet <ruben.de.smet@rubdos.be>
 
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
 index 40eb910fdc3..8798aa7061c 100644
---- a/library/std/src/sys/unix/fs.rs
-+++ b/library/std/src/sys/unix/fs.rs
-@@ -17,28 +17,11 @@
- use crate::sys::{cvt, cvt_r};
- use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
+--- a/library/std/src/sys/pal/unix/fs.rs
++++ b/library/std/src/sys/pal/unix/fs.rs
+@@ -17,8 +17,6 @@
+ #[cfg(test)]
+ mod tests;
  
--#[cfg(any(
--    all(target_os = "linux", target_env = "gnu"),
--    target_os = "macos",
--    target_os = "ios",
--    target_os = "tvos",
--    target_os = "watchos",
--))]
--use crate::sys::weak::syscall;
- #[cfg(any(target_os = "android", target_os = "macos", target_os = "solaris"))]
- use crate::sys::weak::weak;
- 
- use libc::{c_int, mode_t};
- 
--#[cfg(any(
--    target_os = "macos",
--    target_os = "ios",
--    target_os = "tvos",
--    target_os = "watchos",
--    target_os = "solaris",
--    all(target_os = "linux", target_env = "gnu")
--))]
+-#[cfg(all(target_os = "linux", target_env = "gnu"))]
 -use libc::c_char;
  #[cfg(any(
      all(target_os = "linux", not(target_env = "musl")),
      target_os = "emscripten",
-@@ -117,20 +100,9 @@
+@@ -19,8 +19,6 @@
+ use crate::sys::common::small_c_string::run_path_with_cstr;
+ use crate::sys::fd::FileDesc;
+ use crate::sys::time::SystemTime;
+-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+-use crate::sys::weak::syscall;
+ #[cfg(target_os = "android")]
+ use crate::sys::weak::weak;
+ use crate::sys::{cvt, cvt_r};
+@@ -102,20 +102,9 @@
  // https://github.com/rust-lang/rust/pull/67774
  macro_rules! cfg_has_statx {
      ({ $($then_tt:tt)* } else { $($else_tt:tt)* }) => {
@@ -75,6 +64,4 @@ index 40eb910fdc3..8798aa7061c 100644
  }
  
  cfg_has_statx! {{
--- 
-2.43.0
 

--- a/0005-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
+++ b/0005-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
@@ -42,8 +42,8 @@ Signed-off-by: Ruben De Smet <ruben.de.smet@rubdos.be>
 
 diff --git a/library/std/src/sys/unix/process/process_common.rs b/library/std/src/sys/unix/process/process_common.rs
 index bac32d9e60e..3cd9767da88 100644
---- a/library/std/src/sys/unix/process/process_common.rs
-+++ b/library/std/src/sys/unix/process/process_common.rs
+--- a/library/std/src/sys/pal/unix/process/process_common.rs
++++ b/library/std/src/sys/pal/unix/process/process_common.rs
 @@ -85,7 +85,7 @@ pub unsafe fn sigaddset(set: *mut libc::sigset_t, signum: libc::c_int) -> libc::
  ////////////////////////////////////////////////////////////////////////////////
  
@@ -157,17 +157,17 @@ index bac32d9e60e..3cd9767da88 100644
          let arg = os2c(arg, &mut self.saw_nul);
 diff --git a/library/std/src/sys/unix/process/process_unix.rs b/library/std/src/sys/unix/process/process_unix.rs
 index 72aca4e6659..495368b58ec 100644
---- a/library/std/src/sys/unix/process/process_unix.rs
-+++ b/library/std/src/sys/unix/process/process_unix.rs
-@@ -25,7 +25,7 @@
+--- a/library/std/src/sys/pal/unix/process/process_unix.rs
++++ b/library/std/src/sys/pal/unix/process/process_unix.rs
+@@ -1,7 +1,7 @@
+ #[cfg(target_os = "vxworks")]
  use libc::RTP_ID as pid_t;
- 
  #[cfg(not(target_os = "vxworks"))]
 -use libc::{c_int, pid_t};
 +use libc::{c_char, c_int, dlsym, pid_t};
- 
  #[cfg(not(any(
      target_os = "vxworks",
+     target_os = "l4re",
 @@ -62,6 +62,10 @@ fn get_clock_resolution() -> Duration {
      }
  }
@@ -333,12 +333,20 @@ index 72aca4e6659..495368b58ec 100644
              }
              if let Some(u) = self.get_uid() {
                  // When dropping privileges from root, the `setgroups` call
-@@ -337,13 +440,13 @@ unsafe fn do_exec(
+@@ -337,21 +440,21 @@ unsafe fn do_exec(
                  //FIXME: Redox kernel does not support setgroups yet
                  #[cfg(not(target_os = "redox"))]
-                 if libc::getuid() == 0 && self.get_groups().is_none() {
--                    cvt(libc::setgroups(0, crate::ptr::null()))?;
-+                    cvt(self.unwrap_setgroups(0, crate::ptr::null()))?;
+                 if self.get_groups().is_none() {
+-                    let res = cvt(libc::setgroups(0, crate::ptr::null()));
++                    let res = cvt(self.unwrap_setgroups(0, crate::ptr::null()));
+                     if let Err(e) = res {
+                         // Here we ignore the case of not having CAP_SETGID.
+                         // An alternative would be to require CAP_SETGID (in
+                         // addition to CAP_SETUID) for setting the UID.
+                         if e.raw_os_error() != Some(libc::EPERM) {
+                             return Err(e.into());
+                         }
+                     }
                  }
 -                cvt(libc::setuid(u as uid_t))?;
 +                cvt(self.unwrap_setuid(u as uid_t))?;
@@ -373,9 +381,9 @@ index 72aca4e6659..495368b58ec 100644
          Ok(None)
      }
  
-@@ -459,12 +567,15 @@ fn posix_spawn(
-         use crate::mem::MaybeUninit;
-         use crate::sys::{self, cvt_nz, unix_sigpipe_attr_specified};
+@@ -459,11 +567,14 @@ fn posix_spawn(
+         use crate::sys::weak::weak;
+         use crate::sys::{self, cvt_nz, on_broken_pipe_flag_used};
  
 +        let skip_spawnvp: bool = getenv(&OsString::from("SB2_RUST_NO_SPAWNVP")).is_some();
 +
@@ -384,11 +392,10 @@ index 72aca4e6659..495368b58ec 100644
              || (self.env_saw_path() && !self.program_is_path())
              || !self.get_closures().is_empty()
              || self.get_groups().is_some()
-             || self.get_create_pidfd()
 +            || skip_spawnvp
          {
              return Ok(None);
          }
--- 
+--
 2.43.0
 

--- a/0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
+++ b/0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
@@ -18,7 +18,7 @@ index 73d8f89cc..5d17c15d2 100644
 @@ -71,7 +71,13 @@ impl CompileKind {
          }
  
-         let kinds = match &config.build_config()?.target {
+         let kinds = match &gctx.build_config()?.target {
 -            None => Ok(vec![CompileKind::Host]),
 +            None => {
 +                if let Ok(sb2_tgt) = std::env::var("SB2_RUST_TARGET_TRIPLE") {
@@ -27,7 +27,7 @@ index 73d8f89cc..5d17c15d2 100644
 +                    Ok(vec![CompileKind::Host])
 +                }
 +            }
-             Some(build_target_config) => dedup(&build_target_config.values(config)?),
+             Some(build_target_config) => dedup(&build_target_config.values(gctx)?),
          };
  
 -- 

--- a/0007-Disable-aarch64-outline-atomics-for-now.patch
+++ b/0007-Disable-aarch64-outline-atomics-for-now.patch
@@ -18,14 +18,14 @@ index c0b07db3818..b8f240295be 100644
 --- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
 +++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
 @@ -7,7 +7,7 @@ pub fn target() -> Target {
-         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
+         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
          arch: "aarch64".into(),
          options: TargetOptions {
 -            features: "+v8a,+outline-atomics".into(),
 +            features: "+v8a".into(),
              mcount: "\u{1}_mcount".into(),
              max_atomic_width: Some(128),
-             supported_sanitizers: SanitizerSet::ADDRESS
+             stack_probes: StackProbeType::Inline,
 -- 
 2.43.0
 

--- a/0008-Revert-Use-statx-s-64-bit-times-on-32-bit-linux-gnu.patch
+++ b/0008-Revert-Use-statx-s-64-bit-times-on-32-bit-linux-gnu.patch
@@ -56,8 +56,8 @@ index ab0b2a3eda3..4ac9ae4fd04 100644
          self.as_inner().as_inner().st_ctime_nsec as i64
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
 index 8798aa7061c..1d92664b2e1 100644
---- a/library/std/src/sys/unix/fs.rs
-+++ b/library/std/src/sys/unix/fs.rs
+--- a/library/std/src/sys/pal/unix/fs.rs
++++ b/library/std/src/sys/pal/unix/fs.rs
 @@ -117,19 +117,10 @@ struct StatxExtraFields {
          // This is needed to check if btime is supported by the filesystem.
          stx_mask: u32,
@@ -131,125 +131,43 @@ index 8798aa7061c..1d92664b2e1 100644
      }
  } else {
      impl FileAttr {
-@@ -435,15 +389,24 @@ pub fn file_type(&self) -> FileType {
- #[cfg(target_os = "netbsd")]
- impl FileAttr {
-     pub fn modified(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_mtime as i64, self.stat.st_mtimensec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_mtime as libc::time_t,
-+            tv_nsec: self.stat.st_mtimensec as libc::c_long,
-+        }))
-     }
- 
-     pub fn accessed(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_atime as i64, self.stat.st_atimensec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_atime as libc::time_t,
-+            tv_nsec: self.stat.st_atimensec as libc::c_long,
-+        }))
-     }
- 
-     pub fn created(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_birthtime as i64, self.stat.st_birthtimensec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_birthtime as libc::time_t,
-+            tv_nsec: self.stat.st_birthtimensec as libc::c_long,
-+        }))
-     }
- }
- 
-@@ -472,19 +435,18 @@ impl FileAttr {
+@@ -472,12 +435,6 @@ impl FileAttr {
          target_os = "hurd",
      )))]
      pub fn modified(&self) -> io::Result<SystemTime> {
 -        #[cfg(target_pointer_width = "32")]
 -        cfg_has_statx! {
 -            if let Some(mtime) = self.stx_mtime() {
--                return Ok(SystemTime::new(mtime.tv_sec, mtime.tv_nsec as i64));
+-                return SystemTime::new(mtime.tv_sec, mtime.tv_nsec as i64);
 -            }
 -        }
--
--        Ok(SystemTime::new(self.stat.st_mtime as i64, self.stat.st_mtime_nsec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_mtime as libc::time_t,
-+            tv_nsec: self.stat.st_mtime_nsec as _,
-+        }))
-     }
  
-     #[cfg(any(target_os = "vxworks", target_os = "espidf", target_os = "vita"))]
-     pub fn modified(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_mtime as i64, 0))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_mtime as libc::time_t,
-+            tv_nsec: 0,
-+        }))
+         SystemTime::new(self.stat.st_mtime as i64, self.stat.st_mtime_nsec as i64)
      }
- 
-     #[cfg(any(target_os = "horizon", target_os = "hurd"))]
-@@ -500,19 +462,18 @@ pub fn modified(&self) -> io::Result<SystemTime> {
+@@ -500,12 +462,6 @@ pub fn modified(&self) -> io::Result<SystemTime> {
          target_os = "hurd",
      )))]
      pub fn accessed(&self) -> io::Result<SystemTime> {
 -        #[cfg(target_pointer_width = "32")]
 -        cfg_has_statx! {
 -            if let Some(atime) = self.stx_atime() {
--                return Ok(SystemTime::new(atime.tv_sec, atime.tv_nsec as i64));
+-                return SystemTime::new(atime.tv_sec, atime.tv_nsec as i64);
 -            }
 -        }
--
--        Ok(SystemTime::new(self.stat.st_atime as i64, self.stat.st_atime_nsec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_atime as libc::time_t,
-+            tv_nsec: self.stat.st_atime_nsec as _,
-+        }))
-     }
  
-     #[cfg(any(target_os = "vxworks", target_os = "espidf", target_os = "vita"))]
-     pub fn accessed(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_atime as i64, 0))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_atime as libc::time_t,
-+            tv_nsec: 0,
-+        }))
+         SystemTime::new(self.stat.st_atime as i64, self.stat.st_atime_nsec as i64)
      }
- 
-     #[cfg(any(target_os = "horizon", target_os = "hurd"))]
-@@ -529,7 +490,10 @@ pub fn accessed(&self) -> io::Result<SystemTime> {
-         target_os = "watchos",
-     ))]
-     pub fn created(&self) -> io::Result<SystemTime> {
--        Ok(SystemTime::new(self.stat.st_birthtime as i64, self.stat.st_birthtime_nsec as i64))
-+        Ok(SystemTime::from(libc::timespec {
-+            tv_sec: self.stat.st_birthtime as libc::time_t,
-+            tv_nsec: self.stat.st_birthtime_nsec as libc::c_long,
-+        }))
-     }
- 
-     #[cfg(not(any(
-@@ -545,7 +509,10 @@ pub fn created(&self) -> io::Result<SystemTime> {
-         cfg_has_statx! {
-             if let Some(ext) = &self.statx_extra_fields {
-                 return if (ext.stx_mask & libc::STATX_BTIME) != 0 {
--                    Ok(SystemTime::new(ext.stx_btime.tv_sec, ext.stx_btime.tv_nsec as i64))
-+                    Ok(SystemTime::from(libc::timespec {
-+                        tv_sec: ext.stx_btime.tv_sec as libc::time_t,
-+                        tv_nsec: ext.stx_btime.tv_nsec as _,
-+                    }))
-                 } else {
-                     Err(io::const_io_error!(
-                         io::ErrorKind::Uncategorized,
 diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
 index f2e86a4fb2b..fee9e07ec01 100644
---- a/library/std/src/sys/unix/time.rs
-+++ b/library/std/src/sys/unix/time.rs
+--- a/library/std/src/sys/pal/unix/time.rs
++++ b/library/std/src/sys/pal/unix/time.rs
 @@ -34,6 +34,7 @@ pub(in crate::sys::unix) struct Timespec {
  
  impl SystemTime {
      #[cfg_attr(any(target_os = "horizon", target_os = "hurd"), allow(unused))]
 +    #[cfg_attr(target_env = "gnu", allow(dead_code))]
-     pub fn new(tv_sec: i64, tv_nsec: i64) -> SystemTime {
-         SystemTime { t: Timespec::new(tv_sec, tv_nsec) }
+     pub fn new(tv_sec: i64, tv_nsec: i64) -> Result<SystemTime, io::Error> {
+         Ok(SystemTime { t: Timespec::new(tv_sec, tv_nsec)? })
      }
 -- 
 2.43.0

--- a/0009-Relocate-unset-tmp.patch
+++ b/0009-Relocate-unset-tmp.patch
@@ -5,7 +5,7 @@ index dd9d277fb..160e472cf 100644
 @@ -48,7 +48,7 @@ use std::ffi::OsString;
  use std::fs::{read, File, OpenOptions};
  use std::io::{BufWriter, Write};
- use std::ops::Deref;
+ use std::ops::{ControlFlow, Deref};
 -use std::path::{Path, PathBuf};
 +use std::path::{MAIN_SEPARATOR, Path, PathBuf};
  use std::process::{ExitStatus, Output, Stdio};
@@ -28,7 +28,7 @@ index dd9d277fb..160e472cf 100644
              let tmpdir = TempFileBuilder::new()
                  .prefix("rustc")
                  .tempdir()
-                 .unwrap_or_else(|error| sess.emit_fatal(errors::CreateTempDir { error }));
+                 .unwrap_or_else(|error| sess.dcx().emit_fatal(errors::CreateTempDir { error }));
              let path = MaybeTempDir::new(tmpdir, sess.opts.cg.save_temps);
 +            if clear_tmp {
 +                env::remove_var("TMP");

--- a/rust-1.75.0-i686-unknown-linux-gnu.tar.gz
+++ b/rust-1.75.0-i686-unknown-linux-gnu.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:107b8d8825deab338f338b15f047829da6225bb34644790847e96f0957c6678f
-size 409233544

--- a/rust-1.82.0-i686-unknown-linux-gnu.tar.gz
+++ b/rust-1.82.0-i686-unknown-linux-gnu.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77b261fb3d9efa7fe39e87c024987495e03b647b6cb23a66b8e69aeb12a8be61
+size 453859154

--- a/rust.spec
+++ b/rust.spec
@@ -11,13 +11,13 @@
 %define rust_use_bootstrap 1
 %define bootstrap_arches i486
 
-%global bootstrap_rust 1.75.0
-%global bootstrap_cargo 1.75.0
+%global bootstrap_rust 1.82.0
+%global bootstrap_cargo 1.82.0
 
 # Only x86_64 and i686 are Tier 1 platforms at this time.
 # https://forge.rust-lang.org/platform-support.html
 
-%global rust_version 1.75.0
+%global rust_version 1.82.0
 
 %ifarch %ix86
 %define xbuildjobs %{nil}
@@ -65,7 +65,7 @@ License:        (ASL 2.0 or MIT) and (BSD and MIT)
 URL:            https://www.rust-lang.org
 
 %global rustc_package rustc-%{rust_version}-src
-Source0:        rustc-%{rust_version}-src.tar.gz
+Source0:        rustc-%{rust_version}-src.tar.xz
 Source100:      rust-%{rust_version}-i686-unknown-linux-gnu.tar.gz
 Source200:      README.md
 
@@ -125,6 +125,7 @@ BuildRequires:  pkgconfig(zlib)
 BuildRequires:  python3-base
 BuildRequires:  llvm-devel
 BuildRequires:  libffi-devel
+BuildRequires:  ninja
 
 # make check needs "ps" for src/test/run-pass/wait-forked-but-failed-child.rs
 BuildRequires:  procps
@@ -259,6 +260,7 @@ test -f '%{local_rust_root}/bin/rustc'
 sed -i.try-py3 -e '/try python2.7/i try python3 "$@"' ./configure
 
 rm -rf src/llvm-project/
+mkdir src/llvm-project
 
 # We never enable other LLVM tools.
 rm -rf src/tools/clang
@@ -335,11 +337,12 @@ PATH=/opt/cross/bin/:$PATH
   --enable-local-rebuild \
   --enable-llvm-link-shared \
   --enable-ccache \
-  --enable-optimize \
+  --enable-optimize-llvm \
   --disable-docs \
   --disable-compiler-docs \
   --disable-jemalloc \
   --disable-rpath \
+  --disable-lld \
   --disable-codegen-tests \
   --disable-verbose-tests \
   %{enable_debuginfo} \
@@ -347,7 +350,7 @@ PATH=/opt/cross/bin/:$PATH
   --enable-vendor \
   --set rust.codegen-units-std=1 \
   --tools=cargo \
-  --llvm-root=/usr/ \
+  --llvm-root=/usr \
   --enable-parallel-compiler \
   --set target.%{rust_x86_triple}.cc=/usr/bin/cc \
   --set target.%{rust_x86_triple}.ar=/usr/bin/ar \
@@ -359,7 +362,8 @@ PATH=/opt/cross/bin/:$PATH
   --set target.%{rust_aarch64_triple}.cc=/opt/cross/bin/aarch64-meego-linux-gnu-cc \
   --set target.%{rust_aarch64_triple}.ar=/opt/cross/bin/aarch64-meego-linux-gnu-ar \
 %endif
-  --set build.verbose=2
+  --set build.verbose=2 \
+  --set build.optimized-compiler-builtins=false
 
 %{python} ./x.py %{xbuildjobs} build
 
@@ -415,12 +419,14 @@ find %{buildroot}%{rustlibdir} -maxdepth 1 -type f -exec rm -v '{}' '+'
 find %{buildroot}%{rustlibdir} -type f -name '*.orig' -exec rm -v '{}' '+'
 
 # Remove unwanted documentation files (we already package them)
-rm -f %{buildroot}%{_docdir}/%{name}/README.md
-rm -f %{buildroot}%{_docdir}/%{name}/COPYRIGHT
-rm -f %{buildroot}%{_docdir}/%{name}/LICENSE
-rm -f %{buildroot}%{_docdir}/%{name}/LICENSE-APACHE
-rm -f %{buildroot}%{_docdir}/%{name}/LICENSE-MIT
-rm -f %{buildroot}%{_docdir}/%{name}/LICENSE-THIRD-PARTY
+rm -f %{buildroot}%{_docdir}/rustc/README.md
+rm -f %{buildroot}%{_docdir}/rustc/COPYRIGHT
+rm -f %{buildroot}%{_docdir}/rustc/LICENSE-APACHE
+rm -f %{buildroot}%{_docdir}/rustc/LICENSE-MIT
+rm -f %{buildroot}%{_docdir}/cargo/README.md
+rm -f %{buildroot}%{_docdir}/cargo/LICENSE-APACHE
+rm -f %{buildroot}%{_docdir}/cargo/LICENSE-MIT
+rm -f %{buildroot}%{_docdir}/cargo/LICENSE-THIRD-PARTY
 rm -f %{buildroot}%{_docdir}/%{name}/*.old
 
 # Create the path for crate-devel packages
@@ -472,7 +478,9 @@ rm -f %{buildroot}%{_libexecdir}/cargo-credential-1password
 %dir %{rustlibdir}
 %dir %{rustlibdir}/%{rust_x86_triple}
 %dir %{rustlibdir}/%{rust_x86_triple}/lib
+%dir %{rustlibdir}/%{rust_x86_triple}/bin
 %{rustlibdir}/%{rust_x86_triple}/lib/*.so
+%{rustlibdir}/%{rust_x86_triple}/bin/*
 #%%exclude %%{_bindir}/*miri
 
 %files std-static-%{rust_x86_triple}

--- a/rustc-1.75.0-src.tar.gz
+++ b/rustc-1.75.0-src.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088
-size 285857065

--- a/rustc-1.82.0-src.tar.xz
+++ b/rustc-1.82.0-src.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1276a0bb8fa12288ba6fa96597d28b40e74c44257c051d3bc02c2b049bb38210
+size 219769328


### PR DESCRIPTION
Hello, I'm trying to move to version 1.82.0. I'm not at all accustomed to rust, its usage and compilation. But well, need to start somewhere. I've currently rebased all the patches on top of 1.82.0. I'm pushing this as a WIP, in case this at least could save some work for more knowledgeable people about rust update process.

I'm going to try to compile it in the SDK based on these already existing patches. It must be compiled within the i486 target, right ? Even if I plan to use it later for aarch64 ?