### PR TITLE
Prevent symlink-directory collision chmod attack. Fixes JB#64101

### DIFF
--- a/0010-archive-Prevent-symlink-directory-collision-chmod-at.patch
+++ b/0010-archive-Prevent-symlink-directory-collision-chmod-at.patch
@@ -1,0 +1,284 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 19 Mar 2026 16:58:05 -0500
+Subject: [PATCH] archive: Prevent symlink-directory collision chmod attack
+ (#442)
+
+When unpacking a tarball containing a symlink followed by a directory
+entry with the same path, unpack_dir previously used fs::metadata()
+which follows symlinks. This allowed an attacker to modify permissions
+on arbitrary directories outside the extraction path.
+
+The fix uses fs::symlink_metadata() to detect symlinks and refuse to
+treat them as valid existing directories.
+
+Document more exhaustively+consistently security caveats.
+
+Reported-by: Sergei Zimmerman <https://github.com/xokdvium>
+Assisted-by: OpenCode (Claude claude-opus-4-5)
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Co-authored-by: Colin Walters <walters@verbum.org>
+---
+ vendor/tar-0.4.38/.cargo-checksum.json |  2 +-
+ vendor/tar-0.4.38/src/archive.rs       | 18 +++++++--
+ vendor/tar-0.4.38/src/entry.rs         |  7 ++--
+ vendor/tar-0.4.38/tests/entry.rs       | 56 ++++++++++++++++++++++++++
+ vendor/tar/.cargo-checksum.json        |  2 +-
+ vendor/tar/src/archive.rs              | 18 +++++++--
+ vendor/tar/src/entry.rs                |  7 ++--
+ vendor/tar/tests/entry.rs              | 56 ++++++++++++++++++++++++++
+ 8 files changed, 152 insertions(+), 14 deletions(-)
+
+diff --git a/vendor/tar-0.4.38/.cargo-checksum.json b/vendor/tar-0.4.38/.cargo-checksum.json
+index 508f784e8..16ed33bac 100644
+--- a/vendor/tar-0.4.38/.cargo-checksum.json
++++ b/vendor/tar-0.4.38/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"85a0091e02690c62379137988cd9b2689009536a0b941f1ab0581db26e9ebce6","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"705016636f7fdcad4fe20d7d2672be2b94cc53bb05e47628f5212b89e17a40fe","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"c1411ee09da9edb659b508867f0960e804966dfd33801f4a7afaefda331479dd","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"4eac362ffc7bf629fcecf88ca43cec96a1753c9e0a759722d916a9931c093e25","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+diff --git a/vendor/tar-0.4.38/src/archive.rs b/vendor/tar-0.4.38/src/archive.rs
+index 1bed51249..056eb71a1 100644
+--- a/vendor/tar-0.4.38/src/archive.rs
++++ b/vendor/tar-0.4.38/src/archive.rs
+@@ -88,9 +88,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar-0.4.38/src/entry.rs b/vendor/tar-0.4.38/src/entry.rs
+index 8f0b62acf..287d68904 100644
+--- a/vendor/tar-0.4.38/src/entry.rs
++++ b/vendor/tar-0.4.38/src/entry.rs
+@@ -210,8 +210,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -430,7 +431,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar-0.4.38/tests/entry.rs b/vendor/tar-0.4.38/tests/entry.rs
+index fa8eeaee7..5e874fa5d 100644
+--- a/vendor/tar-0.4.38/tests/entry.rs
++++ b/vendor/tar-0.4.38/tests/entry.rs
+@@ -377,3 +377,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+diff --git a/vendor/tar/.cargo-checksum.json b/vendor/tar/.cargo-checksum.json
+index 77504e32a..433701f56 100644
+--- a/vendor/tar/.cargo-checksum.json
++++ b/vendor/tar/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"1e1da319c4d28693a3e42e014ed00828480994b55b15003052f21f2342a346bb","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"e38b876270e3e4e7bac24fc4bf74e05df362102113cf0e024334a853a824f61e","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"0e4b0438cbc4cbec30a821ce8f23619fe9e53c17022a022de609d642e220193c","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"81bfe5fb71e8d2dd7455c126fc77aa40c2011a2cd5871d785e39e6fb053bf352","tests/entry.rs":"af12d84160e5459ebaee6ecdd68e0c811438c37c0cb881ad210e7f94132b9739","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"1e1da319c4d28693a3e42e014ed00828480994b55b15003052f21f2342a346bb","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"44b5de68d031997c0ceb4b3904973470f4020dbfeb910c09ebef31fecf9065f7","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"e73bbec8dbd20a7ab5453c45b908b3a02e0c7f3854cf9716f87120f556e4f0e2","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"81bfe5fb71e8d2dd7455c126fc77aa40c2011a2cd5871d785e39e6fb053bf352","tests/entry.rs":"f89b56fc984d17ca2050b0ecda365974b1ff8c3fa0fd7a9363248e824638b8fc","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
+diff --git a/vendor/tar/src/archive.rs b/vendor/tar/src/archive.rs
+index 760b2cb82..9ee31deff 100644
+--- a/vendor/tar/src/archive.rs
++++ b/vendor/tar/src/archive.rs
+@@ -92,9 +92,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar/src/entry.rs b/vendor/tar/src/entry.rs
+index c81554fcb..1e6952cea 100644
+--- a/vendor/tar/src/entry.rs
++++ b/vendor/tar/src/entry.rs
+@@ -212,8 +212,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -446,7 +447,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar/tests/entry.rs b/vendor/tar/tests/entry.rs
+index 62df663e8..2c2082f06 100644
+--- a/vendor/tar/tests/entry.rs
++++ b/vendor/tar/tests/entry.rs
+@@ -408,3 +408,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}

--- a/rust.changes
+++ b/rust.changes
@@ -1,3 +1,6 @@
+* Wed Apr 22 2026 Matti Viljanen <matti.viljanen@jolla.com> - 1.75.0+git2
+- [rust] Prevent symlink-directory collision chmod attack. Fixes JB#64101
+
 * Fri Mar 15 2024 Ruben De Smet <ruben.de.smet@rubdos.be> - 1.75.0+git1
 - [rust] Update to version 1.75.0. JB#61739
 
@@ -34,7 +37,7 @@
 - [rust] Enable cross-building. JB#50499
 - Add support for default targets
 - Enable use of host-cc
-- Partial fix for fork/exec deadlocks in rust's std:: library. 
+- Partial fix for fork/exec deadlocks in rust's std:: library.
 
 * Tue Nov 3 2020 Niels Breet <niels.breet@jolla.com> - 1.44.0+git5
 - [rust] Limit memory usage for aarch64 builds. JB#50504

--- a/rust.spec
+++ b/rust.spec
@@ -78,6 +78,7 @@ Patch6: 0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
 Patch7: 0007-Disable-aarch64-outline-atomics-for-now.patch
 Patch8: 0008-Revert-Use-statx-s-64-bit-times-on-32-bit-linux-gnu.patch
 Patch9: 0009-Relocate-unset-tmp.patch
+Patch10: 0010-archive-Prevent-symlink-directory-collision-chmod-at.patch
 # This is the real rustc spec - the stub one appears near the end.
 %ifarch %ix86
 


### PR DESCRIPTION
There were two vendored tar-rs versions so this patches them both.